### PR TITLE
Return null when chord not found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,6 @@ function Ukelele(props) {
   ];
 
   let circleComponents = [];
-  let chordSchema;
   if (chordExist) {
     const chordSchema = CHORDS[chord]
     chordSchema.forEach(function (finger) {
@@ -57,6 +56,8 @@ function Ukelele(props) {
       </svg>
     );
   }
+
+  return null;
 }
 
 Ukelele.defaultProps = {

--- a/src/ukelele-chords.js
+++ b/src/ukelele-chords.js
@@ -90,6 +90,18 @@ export const CHORDS = {
       fingerId: 1
     }
   ],
+  Csus4: [
+    {
+      string: [1],
+      fret: 3,
+      fingerId: 1
+    },
+    {
+      string: [2],
+      fret: 1,
+      fingerId: 2
+    }
+  ],
   D: [
     {
       string: [2],
@@ -304,6 +316,18 @@ export const CHORDS = {
       string: [1],
       fret: 2,
       fingerId: 3
+    }
+  ],
+  G6: [
+    {
+      string: [1],
+      fret: 2,
+      fingerId: 1
+    },
+    {
+      string: [3],
+      fret: 2,
+      fingerId: 2
     }
   ]
 };


### PR DESCRIPTION
This is a quick fix to prevent errors when a chord is not found.

Perhaps we should return an empty headstock, but that's for another time. Curious what you think?

Also I added 2 chords and will add more later if you don't mind?