### PR TITLE
Fix CommonJS entry path

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/react-ukelele.umd.js",
+  "main": "./dist/react-ukelele.umd.cjs",
   "module": "./dist/react-ukelele.js",
   "exports": {
     ".": {
       "import": "./dist/react-ukelele.js",
-      "require": "./dist/react-ukelele.umd.js"
+      "require": "./dist/react-ukelele.umd.cjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- fix main and require paths to use `react-ukelele.umd.cjs`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684ab54bac048333910a7a11e4a832a9