### PR TITLE
Add Vitest setup and tests

### DIFF
--- a/__tests__/Ukelele.test.tsx
+++ b/__tests__/Ukelele.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Ukelele from '../src';
+
+describe('Ukelele', () => {
+  it('renders expected number of circle elements for chord A', () => {
+    const { container } = render(<Ukelele chord="A" />);
+    const circles = container.querySelectorAll('circle');
+    expect(circles).toHaveLength(2);
+  });
+
+  it('returns null for invalid chord', () => {
+    const { container } = render(<Ukelele chord="Z" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "repository": {
     "type": "git",
@@ -52,6 +53,10 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.3.4",
     "typescript": "^5.0.2",
-    "vite": "^4.3.0"
+    "vite": "^4.3.0",
+    "vitest": "^0.34.6",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^5.16.5",
+    "jsdom": "^22.1.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "__tests__/**/*"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,9 @@ import { resolve } from "path";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
   build: {
     lib: {
       entry: resolve(__dirname, "src/index"),


### PR DESCRIPTION
## Summary
- add Vitest and testing libraries
- configure tsconfig for tests and jsdom
- add sample tests for `Ukelele`
- expose test script in package.json

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab553e95c8333a84d01bfcce18bd6