### PR TITLE
Improve build tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ This is a very basic react module that generates the headstock and the strings o
 npm install react-ukelele
 ```
 
+## Development
+
+Run the following commands to check the codebase:
+
+```bash
+npm run type-check    # validate TypeScript types
+npm run lint          # run eslint
+npm run build         # generate production build
+```
+
 ## How to use
 **To render** the component you just need to pass the `chord` prop. The list of chords available can be seen in [here](https://github.com/newpatriks/ukelele/blob/master/src/ukelele-chords.js)
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,28 @@
+import js from '@eslint/js';
+import parser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    languageOptions: {
+      parser,
+      parserOptions: {
+        sourceType: 'module',
+        ecmaVersion: 'latest'
+      }
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh
+    },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn'
+    }
+  }
+];

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*", "__tests__/**/*"],
+  "include": ["src/**/*"],
+  "exclude": ["__tests__"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- add eslint flat config
- run tsc only on source code and ignore tests
- include type-check script and document build commands

## Testing
- `npm run build` *(fails: Cannot find module '@testing-library/react')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_684b3575a4fc833396fd16b271e90ee3